### PR TITLE
env: fix conda python issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Environment
+env/

--- a/environment.yml
+++ b/environment.yml
@@ -6,12 +6,9 @@ dependencies:
   - symbiflow::prjxray-db=0.0_0239_gd87c844
   - symbiflow::prjxray-tools
   - make
-  - lxml
-  - simplejson
-  - intervaltree
   - git
-  - pip
   - gxx_linux-64
   # Packages installed from PyPI
+  - pip
   - pip:
     - -r file:requirements.txt

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - git
   - gxx_linux-64
   # Packages installed from PyPI
+  - python=3.8
   - pip
   - pip:
     - -r file:requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-constraint
-git+https://github.com/symbiflow/fasm
-git+https://github.com/symbiflow/xc-fasm
+git+https://github.com/SymbiFlow/fasm.git#egg=fasm
+git+https://github.com/SymbiFlow/prjxray.git#egg=prjxray
+git+https://github.com/symbiflow/xc-fasm.git#egg=xc-fasm


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR fixes the conda build during pip packages installation. Basically, the xc-fasm package was previously installing dependencies such as `prjxray`, which now should be installed in here, rather then allowing pip to install them automatically.

This is related to recent changes to the xc-fasm repo: https://github.com/SymbiFlow/xc-fasm/pull/7