### PR TITLE
Pin python dependencies

### DIFF
--- a/kokoro/steps/hostsetup.sh
+++ b/kokoro/steps/hostsetup.sh
@@ -79,8 +79,9 @@ sudo apt-get install -y \
         virtualenv \
         wget \
         xdot \
-	xzdec \
+        xzdec \
         zlib1g-dev \
+        libtbb-dev \
 
 echo "----------------------------------------"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-constraint
-git+https://github.com/SymbiFlow/fasm.git#egg=fasm
-git+https://github.com/SymbiFlow/prjxray.git#egg=prjxray
-git+https://github.com/symbiflow/xc-fasm.git#egg=xc-fasm
+git+https://github.com/SymbiFlow/fasm.git@4857dde757edd88688c2faf808774d85bdbe3900#egg=fasm
+git+https://github.com/SymbiFlow/prjxray.git@714f4d9e663e1edfe3df4833dc214af82212fccb#egg=prjxray
+git+https://github.com/symbiflow/xc-fasm.git@e12f31334e96fedf3af86d13cf51f70ad2270f5f#egg=xc-fasm


### PR DESCRIPTION
This PR pins python dependencies and fixes OOM error in CI when creating conda environment. 
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>